### PR TITLE
feat: update webmanifest to reflect Oathguard branding

### DIFF
--- a/public/favicon/site.webmanifest
+++ b/public/favicon/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "MyWebSite",
-  "short_name": "MySite",
+  "name": "Oathguard",
+  "short_name": "Oathguard",
   "icons": [
     {
       "src": "/favicon/web-app-manifest-192x192.png",
@@ -15,7 +15,7 @@
       "purpose": "maskable"
     }
   ],
-  "theme_color": "#ffffff",
-  "background_color": "#ffffff",
+  "theme_color": "#060708",
+  "background_color": "#060708",
   "display": "standalone"
 }


### PR DESCRIPTION
Change the name and short_name to "Oathguard" to align with the
new branding. Update theme_color and background_color to a dark
shade (#060708) for a consistent visual identity across the app.